### PR TITLE
formula でも色付けを可能に・連続的な操作を可能に

### DIFF
--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -133,7 +133,7 @@ export async function table_manipulations(
                 })
             }
             else if (call.manipulation =="numbering") {
-                // テーブル(の行データ)を転置する
+                // 各行に連番を振る
                 if (call.options==undefined) {
                     table_rows = add_row_number({"text_format":"{num}"}, table_rows)
                 } else {

--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -95,7 +95,7 @@ export async function change_maxmin_colored(
         const default_rowidx = (response.header_info_list[0][0]) ? 1 : 0
         const default_colidx = (response.header_info_list[0][1]) ? 1 : 0
 
-        // テーブル(の行データ)を転置する
+        // テーブルの各行・列について、指定に応じて色を付ける
         const table_rows = change_text_color(options, default_rowidx, default_colidx, org_rowobjs_list)
 
         // 更新した行データから、table block object を作成する

--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -299,7 +299,7 @@ export async function table_sorting(
             // 比較範囲からラベルを排除するため、デフォルト開始セルをヘッダーの有無に合わせて設定
         const default_rowidx = (response.header_info_list[0][0]) ? 1 : 0
 
-        // テーブル(の行データ)を転置する
+        // テーブル(の行データ)を並び替える
         const table_rows = sort_tablerows_by_col(options, default_rowidx, org_rowobjs_list)
 
         // 更新した行データから、table block object を作成する

--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -15,7 +15,6 @@ import {
 import {
     add_formula_to_table,
     add_row_number,
-    formula_check,
     change_text_color,
     get_tables_and_rows,
     separate_table,
@@ -42,7 +41,12 @@ export async function add_formula_row_col(
         const default_rowidx = (response.header_info_list[0][0]) ? 1 : 0
         const default_colidx = (response.header_info_list[0][1]) ? 1 : 0
 
-        options.formula_list.forEach(info => formula_check(info.formula, default_rowidx, default_colidx))
+        options.formula_list.forEach(info => {
+            if (( ["R_MAXNAME","R_MINNAME","R_SECONDMAXNAME","R_SECONDMINNAME"].includes(info.formula) && default_rowidx==0) ||
+                ( ["C_MAXNAME","C_MINNAME","C_SECONDMAXNAME","C_SECONDMINNAME"].includes(info.formula) && default_colidx==0)) {
+                    throw new Error("対応するラベル行・列がない場合、NAME系の formula は使用できません")
+                }
+        })
 
         let table_width = response.table_width_list[0]
         const table_rows = add_formula_to_table(options, default_rowidx, default_colidx, org_rowobjs_list)

--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -3,6 +3,7 @@ import { BlockObjectRequest,
         AppendBlockChildrenResponse } from "https://deno.land/x/notion_sdk/src/api-endpoints.ts";
 
 import {
+    ManipulateSet,
     ColorInfo,
     FormulaInfo,
     ImportInfo,
@@ -57,6 +58,110 @@ export async function add_formula_row_col(
         // 更新した行データから、table block object を作成する
         const table_props = { "object": 'block', "type": "table", "has_children": true,
             "table": { "table_width": table_width,
+                "has_column_header": response.header_info_list[0][0],
+                "has_row_header": response.header_info_list[0][1],
+                "children": table_rows
+            }
+        } as BlockObjectRequest
+        
+        // inspcet == true のときは、リクエストには投げずにそのデータを返す
+        if (inspect) {
+            return Promise.resolve({ "results": [table_props] } as AppendBlockChildrenResponse)
+        }
+        
+        // 親要素にテーブルを追加
+        return await notion.blocks.children.append({
+            block_id: response.parent_id,
+            children: [table_props]
+        })
+    })
+}
+
+
+// 
+export async function table_manipulations(
+    notion: Client,
+    url: string,
+    calls: Array<ManipulateSet>,
+    inspect = false
+    ): Promise<AppendBlockChildrenResponse> {
+
+    // 親要素以下の table block object の id と ヘッダーの設定と元のテーブルの列数を取得する
+    return await get_tables_and_rows(notion, url)
+    .then(async (response) => {
+        // 行データから必要な情報を取り出す
+        const org_rowobjs_list: Array<TableRowBlockObject> = response.rowobjs_lists[0]
+
+        // 比較範囲からラベルを排除するため、デフォルト開始セルをヘッダーの有無に合わせて設定
+        const default_rowidx = (response.header_info_list[0][0]) ? 1 : 0
+        const default_colidx = (response.header_info_list[0][1]) ? 1 : 0
+
+        // 処理のチェック
+        const manipus = calls.map( call => call.manipulation)
+        const trans_idx = manipus.findIndex(t => t=="transpose")
+        if ( trans_idx != -1 ) {
+            if ((manipus.length > 2) && (trans_idx!=0 && trans_idx!=manipus.length-1 )  ) {
+                //throw new Error("転置は一番最初あるいは一番最後に実行してください")
+            }
+        }
+
+        // テーブル処理        
+        let table_rows = [...org_rowobjs_list]
+        let new_table_width = response.table_width_list[0]
+        let eval_limit_row = table_rows.length
+        let eval_limit_col = response.table_width_list[0]
+        let new_def_rowidx = default_rowidx
+        let new_def_colidx = default_colidx
+        calls.forEach( call => {
+            if (call.manipulation == "colored") {
+                // テーブルの各行・列について、指定に応じて色を付ける
+                table_rows = change_text_color(call.options, new_def_rowidx, new_def_colidx, table_rows, eval_limit_row, eval_limit_col)
+            }
+            else if (call.manipulation == "fomula") {
+                // 各行・列に対して一様に数式評価を行う行・列を追加する
+                call.options.formula_list.forEach(info => {
+                    if (( ["R_MAXNAME","R_MINNAME","R_SECONDMAXNAME","R_SECONDMINNAME"].includes(info.formula) && new_def_rowidx==0) ||
+                        ( ["C_MAXNAME","C_MINNAME","C_SECONDMAXNAME","C_SECONDMINNAME"].includes(info.formula) && new_def_colidx==0)) {
+                            throw new Error("対応するラベル行・列がない場合、NAME系の formula は使用できません")
+                        }
+                })
+                table_rows = add_formula_to_table(call.options, new_def_rowidx, new_def_colidx, table_rows, eval_limit_row, eval_limit_col)
+                call.options.formula_list.forEach(info => {
+                    if (info.formula.split("_")[0]=="R") {
+                        new_table_width += 1
+                    }
+                })
+            }
+            else if (call.manipulation =="numbering") {
+                // テーブル(の行データ)を転置する
+                if (call.options==undefined) {
+                    table_rows = add_row_number({"text_format":"{num}"}, table_rows)
+                } else {
+                    table_rows = add_row_number(call.options, table_rows)
+                }
+                new_table_width += 1
+                new_def_colidx += 1
+                eval_limit_col += 1
+            }
+            else if (call.manipulation == "sort") {
+                // テーブル(の行データ)をソートする
+                table_rows = sort_tablerows_by_col(call.options, new_def_rowidx, table_rows, eval_limit_row)
+            }
+            else if (call.manipulation == "transpose") {
+                // テーブル(の行データ)を転置する
+                table_rows = [...Array(response.table_width_list[0])].map( (_x, idx) => {
+                    const new_cells = table_rows.map( row => row.table_row.cells[idx] )
+                    return {"object":"block", "type":"table_row", "table_row":{"cells": new_cells}}
+                } );
+                
+                [eval_limit_col, eval_limit_row] = [eval_limit_row, eval_limit_col]
+                new_table_width = table_rows[0].table_row.cells.length
+            }
+        })
+
+        // 更新した行データから、table block object を作成する
+        const table_props = { "object": 'block', "type": "table", "has_children": true,
+            "table": { "table_width": new_table_width,
                 "has_column_header": response.header_info_list[0][0],
                 "has_row_header": response.header_info_list[0][1],
                 "children": table_rows

--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -110,7 +110,7 @@ export async function table_manipulations(
         let new_table_width = response.table_width_list[0]
         let eval_limit_row = table_rows.length
         let eval_limit_col = response.table_width_list[0]
-        let new_def_rowidx = default_rowidx
+        const new_def_rowidx = default_rowidx
         let new_def_colidx = default_colidx
         calls.forEach( call => {
             if (call.manipulation == "colored") {

--- a/base_types.ts
+++ b/base_types.ts
@@ -16,7 +16,7 @@ type FormulaCall = "R_SUM" | "R_AVERAGE" | "R_COUNT" |
 // 操作と設定の組
 export type CallSet = {"manipulation":"sort", "options": SortInfo} | {"manipulation":"numbering", "options": NumberingInfo} |
                 {"manipulation":"colored", "options": ColorInfo} | {"manipulation":"fomula", "options": FormulaInfo} |
-                {"manipulation":"transpose", "options": null} | {"manipulation":"separate", "options": SeparateInfo}
+                {"manipulation":"transpose", "options": null}// | {"manipulation":"separate", "options": SeparateInfo}
 
 
 interface CallInfo {

--- a/base_types.ts
+++ b/base_types.ts
@@ -14,7 +14,7 @@ type FormulaCall = "R_SUM" | "R_AVERAGE" | "R_COUNT" |
 
 
 // 操作と設定の組
-export type CallSet = {"manipulation":"sort", "options": SortInfo} | {"manipulation":"numbering", "options": NumberingInfo} |
+export type ManipulateSet = {"manipulation":"sort", "options": SortInfo} | {"manipulation":"numbering", "options": NumberingInfo} |
                 {"manipulation":"colored", "options": ColorInfo} | {"manipulation":"fomula", "options": FormulaInfo} |
                 {"manipulation":"transpose", "options": null}// | {"manipulation":"separate", "options": SeparateInfo}
 

--- a/base_types.ts
+++ b/base_types.ts
@@ -13,6 +13,20 @@ type FormulaCall = "R_SUM" | "R_AVERAGE" | "R_COUNT" |
                     "C_MIN" | "C_SECONDMIN" | "C_MINNAME" | "C_SECONDMINNAME"
 
 
+// 操作と設定の組
+export type CallSet = {"manipulation":"sort", "option": SortInfo} | {"manipulation":"numbering", "option": NumberingInfo} |
+                {"manipulation":"colored", "option": ColorInfo} | {"manipulation":"fomula", "option": FormulaInfo} |
+                {"manipulation":"transpose", "option": null} | {"manipulation":"separate", "option": SeparateInfo}
+
+
+interface CallInfo {
+    formula: FormulaCall
+    label: string
+    max?: ApiColor
+    min?:ApiColor
+}
+
+
 // セルの中身・セルの行・列インデックス・セルの plain_text をセットにしたもの
 export interface CellObject {
     cell: Array<RichTextItemResponse>|[]
@@ -30,9 +44,10 @@ export interface ColorInfo {
 }
 
 
+
 // 一様な数式行・列の追加の設定をまとまるもの (暫定)
 export interface FormulaInfo {
-    formula_list: Array<{"formula":FormulaCall, "label":string}>
+    formula_list: Array<CallInfo>
 }
 
 

--- a/base_types.ts
+++ b/base_types.ts
@@ -14,9 +14,9 @@ type FormulaCall = "R_SUM" | "R_AVERAGE" | "R_COUNT" |
 
 
 // 操作と設定の組
-export type CallSet = {"manipulation":"sort", "option": SortInfo} | {"manipulation":"numbering", "option": NumberingInfo} |
-                {"manipulation":"colored", "option": ColorInfo} | {"manipulation":"fomula", "option": FormulaInfo} |
-                {"manipulation":"transpose", "option": null} | {"manipulation":"separate", "option": SeparateInfo}
+export type CallSet = {"manipulation":"sort", "options": SortInfo} | {"manipulation":"numbering", "options": NumberingInfo} |
+                {"manipulation":"colored", "options": ColorInfo} | {"manipulation":"fomula", "options": FormulaInfo} |
+                {"manipulation":"transpose", "options": null} | {"manipulation":"separate", "options": SeparateInfo}
 
 
 interface CallInfo {

--- a/functions.ts
+++ b/functions.ts
@@ -110,12 +110,14 @@ function create_cel_matrix(
     direction: "R"|"C" ,
     list: Array<TableRowBlockObject>,
     default_rowidx: number,
-    default_colidx: number
+    default_colidx: number,
+    limit_rowidx: number,
+    limit_colidx: number
 ): Array<Array<CellObject>> {
     let mat: Array<Array<CellObject>>
     if (direction=="R") {
-        mat = list.slice(default_rowidx).map(
-            (rowobj, r_idx) => rowobj.table_row.cells.slice(default_colidx).map(
+        mat = list.slice(default_rowidx, limit_rowidx).map(
+            (rowobj, r_idx) => rowobj.table_row.cells.slice(default_colidx, limit_colidx).map(
                 (cell, c_idx) =>{
                     const text = (cell.length) ? cell.map( ({plain_text}) => plain_text).join("") : ""
                     return {cell, "r_idx": r_idx+default_rowidx, "c_idx": c_idx+default_colidx, text}
@@ -123,8 +125,8 @@ function create_cel_matrix(
             )
         )
     } else {
-        const c_idxs = [...Array(list[0].table_row.cells.length).keys()].slice(default_colidx)
-        mat = c_idxs.map( c_idx => list.slice(default_rowidx).map( (rowobj, r_idx) => {
+        const c_idxs = [...Array(list[0].table_row.cells.length).keys()].slice(default_colidx, limit_colidx)
+        mat = c_idxs.map( c_idx => list.slice(default_rowidx, limit_rowidx).map( (rowobj, r_idx) => {
                 const cell = rowobj.table_row.cells[c_idx]
                 const text = (cell.length) ? cell.map( c => c.plain_text).join("") : ""
                 return {cell, "r_idx": r_idx+default_rowidx, c_idx, text}

--- a/functions.ts
+++ b/functions.ts
@@ -48,7 +48,14 @@ export function add_formula_to_table(
         } else if (direction=="C") {
             let new_cells = cell_mat_by_col.map( target => evaluate_formula("C", formula, target, table_labels) )
             results_texts = [...new_cells]
-            if (default_colidx==1) { new_cells = [set_celldata_obj("text", info.label), ...new_cells] }
+            if (default_colidx > 0) {
+                if (default_colidx > 1) {
+                    const blank_cells = [...Array(default_colidx-1)].map(_x => set_celldata_obj("text",""))
+                    new_cells = [set_celldata_obj("text", info.label), ...blank_cells, ...new_cells] 
+                } else {
+                    new_cells = [set_celldata_obj("text", info.label), ...new_cells] 
+                }
+            }
             table_rows.push( {"object":"block", "type":"table_row", "table_row": {"cells":new_cells}} )
         } else {
             throw new Error("formula が不適切です")

--- a/functions.ts
+++ b/functions.ts
@@ -241,26 +241,6 @@ function evaluate_formula (
 }
 
 
-// 数式処理の命令が適切かどうかチェックするもの
-// 処理命令 + 処理範囲の先頭の行・列のインデックス → 不適切ならエラーを投げる
-export function formula_check (formula_text: string, default_rowidx:number, default_colidx:number): void {
-    const [direction, call] = formula_text.split("_")
-    const direction_match = ["R", "C"].filter(t => t==direction)
-    const call_macth = ["SUM", "AVERAGE", "COUNT", "MAX", "SECONDMAX", "MAXNAME", "SECONDMAXNAME",
-                        "MIN", "SECONDMIN", "MINNAME", "SECONDMINNAME"].filter(t=>t==call)
-    const name_match = [ "MAXNAME", "SECONDMAXNAME", "MINNAME", "SECONDMINNAME"].filter(t=>t==call)
-    if (!(direction_match.length==1 && call_macth.length==1 )) {
-        console.log({direction, call})
-        throw new Error("formula が不適切です")
-    } else if ( name_match.length==1) {
-        if ((direction=="R" && default_rowidx==0)||(direction=="C" && default_colidx==0)) {
-            throw new Error("対応するラベル行・列がない場合、NAME系の formula は使用できません")
-        }
-    }
-}
-
-
-
 // 親要素を指定し、そこに含まれるテーブルに関する情報を取得する
 // 親要素を含んだURL → 親要素のid、子要素であるテーブルのid・ヘッダー情報・テーブル幅・行データそれぞれのリスト
 export async function get_tables_and_rows(notion:Client, url:string): Promise<TableRowResponces> {

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,6 @@
 export {
     add_formula_row_col,
+    table_manipulations,
     change_maxmin_colored,
     table_from_file,
     table_row_numbering,
@@ -9,6 +10,7 @@ export {
 } from "./Manipulations.ts"
 
 export type {
+    ManipulateSet,
     ColorInfo,
     FormulaInfo,
     ImportInfo,


### PR DESCRIPTION
- **追加**：「数式列・行追加」において、結果行・列に対する色付けの設定を追加 (https://github.com/nikogoli/notion-simple-table-manipulator/commit/3cb0c406575f321ed95a8ee9062716e404ced2fa)
- **更新**：「数式列・行追加」において、ラベル相当の列が1より多い場合にそれらの列を評価対象から外すように変更 (https://github.com/nikogoli/notion-simple-table-manipulator/commit/45379774960786b48be8cd94019285a34e45d28d)
- **変更**：cell_mat 作成時に範囲の右端・下限となる行・列を設定できるように変更し (https://github.com/nikogoli/notion-simple-table-manipulator/commit/be1e49782259486296c2242830ba04d171b3dd63)
    - それに合わせて「数式列・行追加」「色付け」「ソート」のそれぞれにおいて評価範囲を制限するように変更 (https://github.com/nikogoli/notion-simple-table-manipulator/commit/da31a01004b3b067bf3e0b469892c6db013e9003)
- **追加**：操作命令の名称と設定に汎用的に対応する処理関数を追加 (https://github.com/nikogoli/notion-simple-table-manipulator/commit/a3e5d56869f65972599be70364e4ec1dc894f634)
- **変更**：上記の変更に合わせ、それぞれの操作を汎用処理関数を経由する形式に変更 (https://github.com/nikogoli/notion-simple-table-manipulator/commit/19d592f354087d3aefa667226d52f38857fc607f)