### PR TITLE
「複数のテーブルを1つに結合する」操作を追加

### DIFF
--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -36,7 +36,7 @@ export async function add_formula_row_col(
 }
 
 
-// 
+// 汎用処理
 export async function table_manipulations(
     notion: Client,
     url: string,
@@ -59,7 +59,7 @@ export async function table_manipulations(
         const trans_idx = manipus.findIndex(t => t=="transpose")
         if ( trans_idx != -1 ) {
             if ((manipus.length > 2) && (trans_idx!=0 && trans_idx!=manipus.length-1 )  ) {
-                //throw new Error("転置は一番最初あるいは一番最後に実行してください")
+                throw new Error("転置は一番最初あるいは一番最後に実行してください")
             }
         }
 

--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -110,7 +110,6 @@ function maltiple_manipulation (
     
     // 処理
     let table_rows = [...org_table_rows]
-    let new_table_width = response.table_width_list[0]
     let eval_limit_row = table_rows.length
     let eval_limit_col = response.table_width_list[0]
     const new_def_rowidx = default_rowidx
@@ -129,11 +128,6 @@ function maltiple_manipulation (
                     }
             })
             table_rows = add_formula_to_table(call.options, new_def_rowidx, new_def_colidx, table_rows, eval_limit_row, eval_limit_col)
-            call.options.formula_list.forEach(info => {
-                if (info.formula.split("_")[0]=="R") {
-                    new_table_width += 1
-                }
-            })
         }
         else if (call.manipulation =="numbering") {
             // 各行に連番を振る
@@ -142,7 +136,6 @@ function maltiple_manipulation (
             } else {
                 table_rows = add_row_number(call.options, table_rows)
             }
-            new_table_width += 1
             new_def_colidx += 1
             eval_limit_col += 1
         }
@@ -158,7 +151,6 @@ function maltiple_manipulation (
             } );
             
             [eval_limit_col, eval_limit_row] = [eval_limit_row, eval_limit_col]
-            new_table_width = table_rows[0].table_row.cells.length
         }
     })
     return table_rows

--- a/functions.ts
+++ b/functions.ts
@@ -313,6 +313,62 @@ export async function get_tables_and_rows(notion:Client, url:string): Promise<Ta
 }
 
 
+// 結合
+//
+export function join_tabels(
+    table_rows_lists: Array<Array<TableRowBlockObject>>,
+    header_info_list: Array<Array<boolean>>,
+    table_width_list: Array<number>
+) :Array<TableRowBlockObject> {
+
+    let new_rows: Array<Array<Array<RichTextItemResponse>|[]>>
+    if (! header_info_list.map( rowcol => rowcol[0] ).includes(true)) {
+        new_rows = table_rows_lists.map(lis => lis.map(row => row.table_row.cells)).flat()
+    } else {
+        type CellRecord = Record<string, Array<RichTextItemResponse>|[]>
+        const label_record_list: Array<CellRecord> = []
+        const row_records_list: Array<Array<CellRecord>> = []
+        table_rows_lists.forEach( (table_rows, idx) => {
+            const header_info = header_info_list[idx]
+            let label_rec: CellRecord
+            let rows = table_rows
+            if (header_info[0]==true) {
+                label_rec = Object.fromEntries(table_rows[0].table_row.cells.map( 
+                    c => (c.length) ? [c.map(t => t.plain_text).join(), c] : ["", c]
+                ))
+                label_record_list.push(label_rec)
+                rows = table_rows.slice(1)
+            } else {
+                label_rec = label_record_list[label_record_list.length-1]
+            }
+            const labels = [...Object.keys(label_rec)]
+            const row_records: Array<CellRecord> = rows.map(
+                row => Object.fromEntries( row.table_row.cells.map( (cell, idx) => [labels[idx], cell] ) )
+            )
+            row_records_list.push( row_records )
+        })
+
+        const unique_labels = [...new Set( label_record_list.map(rec => [...Object.keys(rec)]).flat() )]
+        let header_row : Array<[] | Array<RichTextItemResponse>>
+        let body_rows : Array<Array<Array<RichTextItemResponse>>>
+        if (unique_labels.length == table_width_list[0]) {
+            header_row = unique_labels.map( lb => label_record_list[0][lb])
+            body_rows = row_records_list.flat().map(rec => unique_labels.map(lb => rec[lb]))
+        } else {
+            const new_label_record: CellRecord = Object.fromEntries(label_record_list.map(rec => Object.entries(rec)).flat())
+            header_row =  unique_labels.map(lb => new_label_record[lb])
+            body_rows = row_records_list.flat().map(rec => unique_labels.map(lb => {
+                return (lb in rec) ? rec[lb] : set_celldata_obj("text","")
+            }) )
+        }
+        new_rows = [header_row, ...body_rows]
+    }
+    return new_rows.map(row => {
+        return {"object":"block", "type":"table_row", "table_row": {"cells":row}} as TableRowBlockObject
+    })
+}
+
+
 // テーブルの分割処理
 // table row block のリスト + 処理の設定 → 分割された複数の table row block のリスト
 export function separate_table(

--- a/functions.ts
+++ b/functions.ts
@@ -315,6 +315,8 @@ export async function get_tables_and_rows(notion:Client, url:string): Promise<Ta
 
 // 結合
 //
+// 全てのテーブルにラベル行がないとき、テーブルはそのまま結合される
+// ラベル行があるものと無いものが混合しているとき、ラベル行がないテーブルはその1つ上に位置するテーブルに合わせて結合される
 export function join_tabels(
     table_rows_lists: Array<Array<TableRowBlockObject>>,
     header_info_list: Array<Array<boolean>>,
@@ -324,6 +326,8 @@ export function join_tabels(
     let new_rows: Array<Array<Array<RichTextItemResponse>|[]>>
     if (! header_info_list.map( rowcol => rowcol[0] ).includes(true)) {
         new_rows = table_rows_lists.map(lis => lis.map(row => row.table_row.cells)).flat()
+    } else if (header_info_list.map( rowcol => rowcol[0] ).includes(true) && header_info_list[0][0]==false) {
+        throw new Error("ラベル行を持つ行列が少なくとも1つある場合、一番上に位置する行列はラベル行を持つものにしてください")
     } else {
         type CellRecord = Record<string, Array<RichTextItemResponse>|[]>
         const label_record_list: Array<CellRecord> = []

--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,7 @@ export {
     table_separation,
     table_sorting,
     table_transposation,
+    table_joining
 } from "./Manipulations.ts"
 
 export type {


### PR DESCRIPTION
- **追加**：異なる列ラベルを許容しつつ複数テーブルを1つに結合する (https://github.com/nikogoli/notion-simple-table-manipulator/commit/c2c2f312d74799113f653d0c03d8c25b6894f7f8)
    - **変更**：結合後に、色付けやソートなどのの追加的な操作を可能に (https://github.com/nikogoli/notion-simple-table-manipulator/commit/618af266bfcdb33555b08a6147d3f5d59e5de666)
- **変更**：汎用処理関数の連続処理部分を、別の関数に切り出し (https://github.com/nikogoli/notion-simple-table-manipulator/commit/caa924c17204a88c17714be912b13c5e164cf2cb)