### PR TITLE
セル単位での数式命令の評価を追加

### DIFF
--- a/Manipulations.ts
+++ b/Manipulations.ts
@@ -18,6 +18,7 @@ import {
 
 import {
     add_formula_to_table,
+    add_formula_to_cell,
     add_row_number,
     change_text_color,
     create_from_text,
@@ -123,6 +124,16 @@ export async function table_manipulations(
             children: [table_props]
         })
     })
+}
+
+
+// 各行・列に対して一様に数式評価を行う行・列を追加する
+export async function calculate_formula_cells(
+    notion: Client,
+    url: string,
+    inspect = false
+    ): Promise<AppendBlockChildrenResponse> {
+    return await table_manipulations(notion, url, [{"manipulation":"calculate", "options":null}], inspect)
 }
 
 
@@ -280,6 +291,10 @@ function maltiple_manipulation (
             } );
             
             [eval_limit_col, eval_limit_row] = [eval_limit_row, eval_limit_col]
+        }
+        else if (call.manipulation == "calculate") {
+            // セルの命令に従い計算
+            table_rows = add_formula_to_cell(new_def_rowidx, new_def_colidx, table_rows)
         }
     })
     return table_rows

--- a/base_types.ts
+++ b/base_types.ts
@@ -18,7 +18,8 @@ export type ManipulateSet = {"manipulation":"sort", "options": SortInfo} |
                             {"manipulation":"numbering", "options": NumberingInfo|null} |
                             {"manipulation":"colored", "options": ColorInfo} |
                             {"manipulation":"fomula", "options": FormulaInfo} |
-                            {"manipulation":"transpose", "options": null}
+                            {"manipulation":"transpose", "options": null} |
+                            {"manipulation":"calculate", "options": null}
                             // | {"manipulation":"separate", "options": SeparateInfo}
 
 


### PR DESCRIPTION
- **追加**：セルにおける数式の評価 (https://github.com/nikogoli/notion-simple-table-manipulator/commit/5387bb3e7405110b54b628d08d1090eeeb24eb76)
    - **更新**：数式命令と四則演算の混合を可能に (https://github.com/nikogoli/notion-simple-table-manipulator/commit/fb6b63e5ee2de058ec3d84bb9831bd0a0ec7a86e)